### PR TITLE
fix: :bug: Afficher le chronon 0

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from CLASSES.Monde import Monde
 from time import sleep
 from os import system, name as system_name
+from parametres import CLEAR_TERMINAL
 
 
 def main() -> None:
@@ -20,12 +21,14 @@ def main() -> None:
     monde_wa_tor = Monde()
     monde_wa_tor.initialiser()
     monde_wa_tor.afficher()
+    sleep(2)
 
     # Ecoulement du temps
     compteur = 0
     while True:
         # Rafraichir le terminal (cls pour windows et clear pour linux)
-        system("cls" if system_name == "nt" else "clear")
+        if CLEAR_TERMINAL:
+            system("cls" if system_name == "nt" else "clear")
 
         monde_wa_tor.executer_chronon()
         monde_wa_tor.afficher()

--- a/parametres.py
+++ b/parametres.py
@@ -1,5 +1,4 @@
 # paramètres de la simulation
-
 NOMBRE_LIGNE_GRILLE = 10
 NOMBRE_COLONNE_GRILLE = 10
 NOMBRE_INITIAUX_POISSON = 20
@@ -10,3 +9,7 @@ TEMPS_GESTION_REQUIN = 5
 TEMPS_GESTION_POISSON = 3
 ENERGIE_INITIALE_REQUIN = 6
 GAIN_ENERGIE_EN_MANGEANT_POISSON = 3
+
+# paramètres de debuggage
+CLEAR_TERMINAL = True # True: ne voir que la dernière carte
+                      # False: conserver l'affichage de toutes les cartes


### PR DESCRIPTION
Garde l'affichage du chronon 0 pendant 2 secs. Ajout du paramètre CLEAR_TERMINAL pour commander le rafraichissement du terminal